### PR TITLE
Yeni yorumlarda post 'up'lama

### DIFF
--- a/protected/modules_core/comment/controllers/CommentController.php
+++ b/protected/modules_core/comment/controllers/CommentController.php
@@ -171,6 +171,8 @@ class CommentController extends Controller
             }
 
             $comment->save();
+            $target->updated_at = new CDbExpression('NOW()');
+	    $target->save();
             File::attachPrecreated($comment, Yii::app()->request->getParam('fileList'));
         }
 

--- a/protected/modules_core/wall/resources/si_streaming.js
+++ b/protected/modules_core/wall/resources/si_streaming.js
@@ -21,7 +21,7 @@ function Stream(baseElement, urlStart, urlReload, urlSingle) {
 
     this.filters = "";
 
-    this.sorting = "c";
+    this.sorting = "u";
 
     /**
      * Return parseHtml result and delete dublicated entries from container


### PR DESCRIPTION
Yeni bir yorum eklendiginde, post'un guncellenme tarihini gunceller. Ana feed icin default siralamayi da bu alana gore yapar.

Friendfeed modeline yakin ama feed saklama (hide), block vs olmadigi icin gicik edebilir.
